### PR TITLE
Remove option '--group=globaleaks' from startup command.

### DIFF
--- a/data/supervisord.conf
+++ b/data/supervisord.conf
@@ -7,6 +7,6 @@ stderr_logfile = /var/log/supervisor/tor-stderr.log
 stdout_logfile = /var/log/supervisor/tor-stdout.log
 
 [program:globaleaks]
-command=/usr/bin/python3 /usr/bin/globaleaks --ip=0.0.0.0 --user=globaleaks --group=globaleaks --working-path=/var/globaleaks/ -n
+command=/usr/bin/python3 /usr/bin/globaleaks --ip=0.0.0.0 --user=globaleaks --working-path=/var/globaleaks/ -n
 stderr_logfile = /var/log/supervisor/globaleaks-stderr.log
 stdout_logfile = /var/log/supervisor/globaleaks-stdout.log


### PR DESCRIPTION
The option does not exist as pointed out by @RrOoSsSsOo in #3.

This is a minimal PR to address the startup issue.

